### PR TITLE
Changed UfDepartment to interface{} because of unstable type

### DIFF
--- a/types/users/user.go
+++ b/types/users/user.go
@@ -32,7 +32,7 @@ type User struct {
 	TimeZone           string      `json:"TIME_ZONE"`
 	TimeZoneOffset     string      `json:"TIME_ZONE_OFFSET"`
 	Title              string      `json:"TITLE"`
-	UfDepartment       []int64     `json:"UF_DEPARTMENT"`
+	UfDepartment       interface{} `json:"UF_DEPARTMENT"`
 	UfDistrict         string      `json:"UF_DISTRICT"`
 	UfEmploymentDate   string      `json:"UF_EMPLOYMENT_DATE"`
 	UfFacebook         string      `json:"UF_FACEBOOK"`


### PR DESCRIPTION
bitrix API can return even `"UF_DEPARTMENT":false` and also `"UF_DEPARTMENT":[3889]` so we will handle the type after unmarshal 
